### PR TITLE
Improve setup documentation and env configs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+# Frontend API endpoint
+VITE_API_URL=http://localhost:10000

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,13 @@
+# Node modules
+node_modules/
+
+# Environment variables
+.env
+backend/.env
+
+# Logs
+npm-debug.log*
+
+# Build output
+/dist
+

--- a/README.md
+++ b/README.md
@@ -1,0 +1,31 @@
+# React Survey Fullstack
+
+這個專案是一個簡易的前後端整合範例，前端使用 Vite + React，後端使用 Express 與 PostgreSQL。
+
+## 使用方式
+
+1. 複製環境設定檔
+
+```bash
+cp .env.example .env
+cp backend/.env.example backend/.env
+```
+
+2. 根據實際環境編輯 `.env` 與 `backend/.env`，設定 API URL、資料庫帳號等參數。
+
+3. 安裝依賴並啟動服務
+
+```bash
+npm install
+npm run dev
+```
+
+後端在 `backend` 目錄下，可使用以下指令啟動：
+
+```bash
+cd backend
+npm install
+npm start
+```
+
+前端預設會連線到 `http://localhost:10000`，可依需求調整。

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,0 +1,12 @@
+# PostgreSQL connection settings
+DB_USER=your_db_user
+DB_PASSWORD=your_db_password
+DB_HOST=localhost
+DB_PORT=5432
+DB_NAME=your_db_name
+
+# HTTP server port
+PORT=10000
+
+# Allowed CORS origin for frontend requests
+ALLOWED_ORIGIN=http://localhost:5173

--- a/backend/index.js
+++ b/backend/index.js
@@ -1,13 +1,14 @@
 const express = require('express');
 const cors = require('cors'); // 我們仍然需要它來處理 OPTIONS 請求
+require('dotenv').config();
 const dbPool = require('./db');
 
 const app = express();
 
 // --- ⚠️ 終極、手動的 CORS 設定中介軟體 ---
 app.use((req, res, next) => {
-  // 您的前端部署網址
-  const allowedOrigin = 'https://survey-form-v4mz.onrender.com';
+  // 您的前端部署網址，可透過環境變數自訂
+  const allowedOrigin = process.env.ALLOWED_ORIGIN || 'https://survey-form-v4mz.onrender.com';
   
   // 為所有回應都強制加上這個標頭
   res.setHeader('Access-Control-Allow-Origin', allowedOrigin);


### PR DESCRIPTION
## Summary
- ignore env files and build output
- document setup in a new README
- provide example env configs for frontend and backend
- allow backend CORS origin via `ALLOWED_ORIGIN` environment variable

## Testing
- `npm run build` *(fails: vite permission denied)*
- `node backend/index.js` *(fails: Cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_684b624bc75483259de33e9d457f1964